### PR TITLE
Add MirrorNotes to Journalling section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -59,6 +59,7 @@ _Please read [contribution guidelines](contributing.md) before contributing._
 ## Journalling
 
 - [Day One](http://dayoneapp.com/) - Write journal entries with multiple photographs and journals [end to end encrypted](http://help.dayoneapp.com/day-one-sync/end-to-end-encryption-faq).
+- [MirrorNotes](https://mirrornotes.org) - Private AI journaling where all AI (daily prompts, mood tracking, Ask-your-journal) runs on-device via Gemma 3. Journal text never leaves your iPhone. Free to write forever.
 
 ## Music
 


### PR DESCRIPTION
Adds [MirrorNotes](https://mirrornotes.org) to the Journalling section alongside Day One.

MirrorNotes is a private AI journaling app for iPhone where all AI (daily prompts, mood tracking, Ask-your-journal queries) runs on-device via Gemma 3 1B. No data transmitted. Free to write forever.

App Store: https://apps.apple.com/app/id6769007201