### PR TITLE
Add justRead to Education (EPUB/PDF/audiobook reader)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -38,6 +38,7 @@ _Please read [contribution guidelines](contributing.md) before contributing._
 
 - [Anki](https://itunes.apple.com/us/app/ankimobile-flashcards/id373493387?mt=8) - Create flashcards to remember things using [spaced repetition learning](http://en.wikipedia.org/wiki/Spaced_repetition).
 - [iBooks](https://itunes.apple.com/nl/app/ibooks/id364709193?l=en&mt=8) - Native reader of ePub and PDF files for iOS.
+- [justRead](https://apps.apple.com/us/app/epub-reader-justread-app/id6757948605) - EPUB, PDF, and audiobook reader with Calibre sync, OPDS support, and 200+ fonts.
 - [Khan Academy](https://itunes.apple.com/us/app/khan-academy-you-can-learn-anything/id469863705?mt=8) - Free educational videos and exercises.
 - [Terminology](http://agiletortoise.com/terminology/) - Quickly lookup unknown words using a dictionary.
 - [V for Wiki](http://v-for-wiki.com/) - Read wikipedia with beautiful typography.


### PR DESCRIPTION
justRead is a native iOS/iPadOS EPUB, PDF, and audiobook reader with Calibre sync, OPDS support, and 200+ fonts. Adding it right after iBooks in the Education section.

App Store: https://apps.apple.com/us/app/epub-reader-justread-app/id6757948605