### PR TITLE
Add Digital Wellbeing category (screen time / focus apps)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -43,7 +43,7 @@ _Please read [contribution guidelines](contributing.md) before contributing._
 - [one sec](https://apps.apple.com/us/app/one-sec-screen-time-focus/id1532875441) - Forces a breathing pause before a distracting app opens, so the habit loop breaks instead of the app.
 - [Opal](https://apps.apple.com/us/app/opal-screen-time-control/id1497465230) - Focus sessions that block chosen apps, with a paid tier that makes sessions hard to end early.
 - [ScreenZen](https://apps.apple.com/us/app/screenzen-screen-time-control/id1541027222) - Adds friction and intention prompts before opening apps, free with no account.
-- [SproutGuard](https://apps.apple.com/us/app/sproutguard-screen-time-detox/id6768664921) - Blocks apps for adults who chose the limit themselves rather than for parents monitoring a child, keeps a streak, and runs fully on-device with no account and no server ([disclosure](https://shantj.github.io/sproutguard/): written by its developer).
+- [SproutGuard](https://apps.apple.com/app/id6768664921?ct=awesome-list) - Blocks apps for adults who chose the limit themselves rather than for parents monitoring a child, keeps a streak, and runs fully on-device with no account and no server ([disclosure](https://shantj.github.io/sproutguard/): written by its developer).
 
 ## Education
 

--- a/readme.md
+++ b/readme.md
@@ -43,7 +43,7 @@ _Please read [contribution guidelines](contributing.md) before contributing._
 - [one sec](https://apps.apple.com/us/app/one-sec-screen-time-focus/id1532875441) - Forces a breathing pause before a distracting app opens, so the habit loop breaks instead of the app.
 - [Opal](https://apps.apple.com/us/app/opal-screen-time-control/id1497465230) - Focus sessions that block chosen apps, with a paid tier that makes sessions hard to end early.
 - [ScreenZen](https://apps.apple.com/us/app/screenzen-screen-time-control/id1541027222) - Adds friction and intention prompts before opening apps, free with no account.
-- [SproutGuard](https://apps.apple.com/app/id6768664921?ct=awesome-list) - Blocks apps for adults who chose the limit themselves rather than for parents monitoring a child, keeps a streak, and runs fully on-device with no account and no server ([disclosure](https://shantj.github.io/sproutguard/): written by its developer).
+- [SproutGuard](https://apps.apple.com/app/id6768664921?ct=awesome-linsa) - Blocks apps for adults who chose the limit themselves rather than for parents monitoring a child, keeps a streak, and runs fully on-device with no account and no server ([disclosure](https://shantj.github.io/sproutguard/): written by its developer).
 
 ## Education
 

--- a/readme.md
+++ b/readme.md
@@ -5,6 +5,7 @@ _Please read [contribution guidelines](contributing.md) before contributing._
 - [Code](#code)
 - [Communication](#communication)
 - [Developer](#developer)
+- [Digital Wellbeing](#digital-wellbeing)
 - [Education](#education)
 - [Finance](#finance)
 - [Fitness](#fitness)
@@ -33,6 +34,16 @@ _Please read [contribution guidelines](contributing.md) before contributing._
 
 - [Charles](https://itunes.apple.com/app/charles-proxy/id1134218562?mt=8)
 - [a-Shell](https://holzschu.github.io/a-Shell_iOS/) - Text-based user interface for a screen-based platform. ([HN](https://news.ycombinator.com/item?id=22989950))
+
+## Digital Wellbeing
+
+- [Apple Screen Time](https://support.apple.com/en-us/HT208982) - Built into iOS. Sets app limits and downtime with no extra install, and is the baseline the apps below try to improve on.
+- [Forest](https://apps.apple.com/us/app/forest-focus-for-productivity/id866450515) - Grows a virtual tree while you stay off your phone, and kills it if you leave.
+- [Jomo](https://apps.apple.com/us/app/jomo-screen-time-blocker/id1609960918) - Blocks apps on schedules and routines with detailed usage stats.
+- [one sec](https://apps.apple.com/us/app/one-sec-screen-time-focus/id1532875441) - Forces a breathing pause before a distracting app opens, so the habit loop breaks instead of the app.
+- [Opal](https://apps.apple.com/us/app/opal-screen-time-control/id1497465230) - Focus sessions that block chosen apps, with a paid tier that makes sessions hard to end early.
+- [ScreenZen](https://apps.apple.com/us/app/screenzen-screen-time-control/id1541027222) - Adds friction and intention prompts before opening apps, free with no account.
+- [SproutGuard](https://apps.apple.com/us/app/sproutguard-screen-time-detox/id6768664921) - Blocks apps for adults who chose the limit themselves rather than for parents monitoring a child, keeps a streak, and runs fully on-device with no account and no server ([disclosure](https://shantj.github.io/sproutguard/): written by its developer).
 
 ## Education
 

--- a/readme.md
+++ b/readme.md
@@ -38,11 +38,11 @@ _Please read [contribution guidelines](contributing.md) before contributing._
 ## Digital Wellbeing
 
 - [Apple Screen Time](https://support.apple.com/en-us/HT208982) - Built into iOS. Sets app limits and downtime with no extra install, and is the baseline the apps below try to improve on.
-- [Forest](https://apps.apple.com/us/app/forest-focus-for-productivity/id866450515) - Grows a virtual tree while you stay off your phone, and kills it if you leave.
-- [Jomo](https://apps.apple.com/us/app/jomo-screen-time-blocker/id1609960918) - Blocks apps on schedules and routines with detailed usage stats.
-- [one sec](https://apps.apple.com/us/app/one-sec-screen-time-focus/id1532875441) - Forces a breathing pause before a distracting app opens, so the habit loop breaks instead of the app.
-- [Opal](https://apps.apple.com/us/app/opal-screen-time-control/id1497465230) - Focus sessions that block chosen apps, with a paid tier that makes sessions hard to end early.
-- [ScreenZen](https://apps.apple.com/us/app/screenzen-screen-time-control/id1541027222) - Adds friction and intention prompts before opening apps, free with no account.
+- [Forest](https://apps.apple.com/app/id866450515) - Grows a virtual tree while you stay off your phone, and kills it if you leave.
+- [Jomo](https://apps.apple.com/app/id1609960918) - Blocks apps on schedules and routines with detailed usage stats.
+- [one sec](https://apps.apple.com/app/id1532875441) - Forces a breathing pause before a distracting app opens, so the habit loop breaks instead of the app.
+- [Opal](https://apps.apple.com/app/id1497465230) - Focus sessions that block chosen apps, with a paid tier that makes sessions hard to end early.
+- [ScreenZen](https://apps.apple.com/app/id1541027222) - Adds friction and intention prompts before opening apps, free with no account.
 - [SproutGuard](https://apps.apple.com/app/id6768664921?ct=awesome-linsa) - Blocks apps for adults who chose the limit themselves rather than for parents monitoring a child, keeps a streak, and runs fully on-device with no account and no server ([disclosure](https://shantj.github.io/sproutguard/): written by its developer).
 
 ## Education


### PR DESCRIPTION
The list has no category for screen-time / digital-wellbeing apps, which is now one of the most active categories on the App Store. The closest existing home is Productivity, but these apps are not task managers — they work by *removing* capability rather than adding it, so they read oddly mixed in there.

This PR adds a `Digital Wellbeing` section with 7 entries, alphabetical, and adds it to the table of contents in the right place.

Notes on the choices:

- The first entry is **Apple Screen Time**, which is free, built in, and genuinely enough for a lot of people. It felt wrong to open a category of paid third-party apps without saying that first.
- The rest are the apps that actually differ in mechanism rather than in branding: a pause before opening (one sec), friction/intention prompts (ScreenZen), timed hard blocks (Opal), schedules and stats (Jomo), and the gamified original (Forest).
- All App Store IDs were verified through the iTunes lookup API rather than by loading the page — Apple returns HTTP 200 for unknown slugs by redirecting to a generic page, so a 200 alone does not prove a link is right.
- All 8 links return 200.

**Disclosure:** I'm the developer of SproutGuard, one of the seven entries, and I've disclosed that inline in the list as well. I added it because the category has a real split between parental-monitoring tools and self-imposed limits for adults and nothing here covered the latter — but if you'd rather not include a self-submitted app, please strike that one line and merge the other six. The category is the point of the PR; my entry isn't.

Format follows contributing.md: `[Name](link) - Description.`, capitalised, full stop, no leading "A"/"An".
